### PR TITLE
feat: Thêm tính năng hủy lời mời kết bạn và tìm kiếm người dùng

### DIFF
--- a/app/Http/Controllers/Api/V1/FriendController.php
+++ b/app/Http/Controllers/Api/V1/FriendController.php
@@ -112,11 +112,23 @@ class FriendController extends Controller
     /**
      *
      * @return JsonResponse
-     */
-    public function getSentRequests(): JsonResponse
+     */    public function getSentRequests(): JsonResponse
     {
         $result = $this->friendService->getSentFriendRequests();
 
+        return response()->json($result, $result['success'] ? 200 : 400);
+    }
+    
+    /**
+     * Cancel a friend request that the user has sent
+     * 
+     * @param string $requestId
+     * @return JsonResponse
+     */
+    public function cancelFriendRequest(string $requestId): JsonResponse
+    {
+        $result = $this->friendService->cancelFriendRequest($requestId);
+        
         return response()->json($result, $result['success'] ? 200 : 400);
     }
 

--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -24,7 +24,7 @@ class UserController extends Controller
     {
         try {
             $user = $this->userService->getCurrentUser();
-            
+
             return response()->json([
                 'success' => true,
                 'data' => $user
@@ -34,7 +34,7 @@ class UserController extends Controller
                 'error' => true,
                 'message' => 'Không tìm thấy thông tin người dùng',
             ], 404);
-        } 
+        }
     }
 
     public function updateProfile(UpdateProfileRequest $request): JsonResponse
@@ -42,7 +42,7 @@ class UserController extends Controller
         try {
             $userDTO = UserDTO::fromRequest($request);
             $updatedUser = $this->userService->updateProfile($userDTO);
-            
+
             return response()->json([
                 'success' => true,
                 'message' => 'Cập nhật thông tin thành công',
@@ -58,26 +58,24 @@ class UserController extends Controller
 
     public function changePassword(ChangePasswordRequest $request): JsonResponse
     {
-        try
-        {
+        try {
             $result = $this->userService->changePassword(
                 $request->get('current_password'),
                 $request->get('new_password')
             );
-            
+
             if (!$result) {
                 return response()->json([
                     'success' => false,
                     'message' => 'Current password is incorrect'
                 ], 400);
             }
-            
+
             return response()->json([
                 'success' => true,
                 'message' => 'Password changed successfully'
             ]);
-        }
-        catch (DataNotFoundException $e) {
+        } catch (DataNotFoundException $e) {
             return response()->json([
                 'error' => true,
                 'message' => 'Không tìm thấy thông tin người dùng',
@@ -90,15 +88,15 @@ class UserController extends Controller
         $request->validate([
             'avatar' => 'required|image|mimes:jpeg,png,jpg,gif|max:2048'
         ]);
-        
+
         $avatarPath = $this->userService->uploadAvatar($request->file('avatar'));
-        
+
         return response()->json([
             'success' => true,
             'message' => 'Avatar uploaded successfully',
             'data' => [
-                'avatar_path' => $avatarPath
-            ]
+                    'avatar_path' => $avatarPath
+                ]
         ]);
     }
 
@@ -106,7 +104,7 @@ class UserController extends Controller
     {
         try {
             $stats = $this->userService->getUserStats();
-            
+
             return response()->json([
                 'success' => true,
                 'data' => $stats
@@ -116,6 +114,30 @@ class UserController extends Controller
                 'error' => true,
                 'message' => 'Không tìm thấy dữ liệu thống kê',
             ], 404);
+        }
+    }
+    /**
+     * Get all users with optional username search for friend requests
+     * 
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function getAllUsers(Request $request): JsonResponse
+    {
+        try {
+            $username = $request->query('username');
+            $users = $this->userService->getAllUsers($username);
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Lấy danh sách người dùng thành công',
+                'data' => $users
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'error' => true,
+                'message' => 'Có lỗi xảy ra khi lấy danh sách người dùng: ' . $e->getMessage(),
+            ], 500);
         }
     }
 }

--- a/app/Providers/RepositoryServiceProvider.php
+++ b/app/Providers/RepositoryServiceProvider.php
@@ -27,6 +27,8 @@ use App\Repositories\Interfaces\FriendRepositoryInterface;
 use App\Repositories\FriendRepository;
 use App\Repositories\Interfaces\FriendRequestRepositoryInterface;
 use App\Repositories\FriendRequestRepository;
+use App\Repositories\Interfaces\UserRepositoryInterface;
+use App\Repositories\UserRepository;
 use App\Services\FriendService;
 
 
@@ -70,6 +72,11 @@ class RepositoryServiceProvider extends ServiceProvider
         $this->app->bind(
             \App\Repositories\Interfaces\FriendRequestRepositoryInterface::class,
             \App\Repositories\FriendRequestRepository::class
+        );
+
+        $this->app->bind(
+            \App\Repositories\Interfaces\UserRepositoryInterface::class,
+            \App\Repositories\UserRepository::class
         );
 
         // Đăng ký service bindings

--- a/app/Repositories/FriendRequestRepository.php
+++ b/app/Repositories/FriendRequestRepository.php
@@ -197,6 +197,35 @@ class FriendRequestRepository extends BaseRepository implements FriendRequestRep
             ->where('receiver_id', $receiverId)
             ->where('status', 'pending')
             ->first();
+    }    /**
+     * Cancel/delete a friend request sent by the user
+     *
+     * @param string $requestId
+     * @param string $userId
+     * @return bool
+     * @throws InvalidParamException
+     */
+    public function cancelFriendRequest(string $requestId, string $userId): bool
+    {
+        // Find the request
+        $request = $this->findFriendRequestById($requestId);
+        
+        if (!$request) {
+            throw new InvalidParamException('Không tìm thấy lời mời kết bạn');
+        }
+        
+        // Make sure the logged in user is the sender
+        if ($request->sender_id !== $userId) {
+            throw new InvalidParamException('Bạn không có quyền xóa lời mời kết bạn này');
+        }
+        
+        // Check if the request is still in pending state
+        if ($request->status !== 'pending') {
+            throw new InvalidParamException('Lời mời kết bạn đã được xử lý trước đó');
+        }
+        
+        // Delete the request
+        return $request->delete();
     }
 
     /**

--- a/app/Repositories/Interfaces/FriendRequestRepositoryInterface.php
+++ b/app/Repositories/Interfaces/FriendRequestRepositoryInterface.php
@@ -21,14 +21,20 @@ interface FriendRequestRepositoryInterface
      * @param string $userId
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function getReceivedFriendRequests(string $userId);
+    public function getReceivedFriendRequests(string $userId);    /**
+            *
+            * @param string $userId
+            * @return \Illuminate\Database\Eloquent\Collection
+            */
+    public function getSentFriendRequests(string $userId);
 
     /**
      *
+     * @param string $requestId
      * @param string $userId
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return bool
      */
-    public function getSentFriendRequests(string $userId);
+    public function cancelFriendRequest(string $requestId, string $userId): bool;
 
     /**
      *

--- a/app/Repositories/Interfaces/UserRepositoryInterface.php
+++ b/app/Repositories/Interfaces/UserRepositoryInterface.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Repositories\Interfaces;
+
+use App\Models\User;
+use App\DTOs\UserDTO;
+use Illuminate\Database\Eloquent\Collection;
+
+interface UserRepositoryInterface
+{
+    /**
+     * Get the currently authenticated user
+     *
+     * @return User
+     */
+    public function getCurrentUser(): User;
+
+    /**
+     * Update user profile information
+     *
+     * @param User $user
+     * @param UserDTO $userDTO
+     * @return User
+     */
+    public function updateProfile(User $user, UserDTO $userDTO): User;
+
+    /**
+     * Update user password
+     *
+     * @param User $user
+     * @param string $password
+     * @return bool
+     */
+    public function updatePassword(User $user, string $password): bool;
+
+    /**
+     * Update user avatar
+     *
+     * @param User $user
+     * @param string $avatarPath
+     * @return User
+     */
+    public function updateAvatar(User $user, string $avatarPath): User;
+
+    /**
+     * Update user statistics
+     *
+     * @param User $user
+     * @param array $stats
+     * @return User
+     */
+    public function updateStats(User $user, array $stats): User;
+
+    /**
+     * Get user by ID
+     *
+     * @param string $userId
+     * @return User|null
+     */
+    public function getUserById(string $userId): ?User;
+
+    /**
+     * Get all users with optional username search
+     *
+     * @param string|null $username
+     * @return Collection
+     */
+    public function getAllUsers(?string $username = null): Collection;
+}

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -4,6 +4,8 @@ namespace App\Repositories;
 
 use App\Models\User;
 use App\DTOs\UserDTO;
+use App\Repositories\Interfaces\UserRepositoryInterface;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Auth;
 
 class UserRepository implements UserRepositoryInterface
@@ -25,7 +27,7 @@ class UserRepository implements UserRepositoryInterface
         if ($updateData) {
             $user->update($updateData);
         }
-        
+
         return $user;
     }
 
@@ -39,7 +41,7 @@ class UserRepository implements UserRepositoryInterface
     {
         $user->avatar = $avatarPath;
         $user->save();
-        
+
         return $user;
     }
 
@@ -52,5 +54,26 @@ class UserRepository implements UserRepositoryInterface
     public function getUserById(string $userId): ?User
     {
         return User::find($userId);
+    }
+
+    /**
+     * Get all users with optional username search
+     *
+     * @param string|null $username
+     * @return Collection
+     */
+    public function getAllUsers(?string $username = null): Collection
+    {
+        $query = User::query()->where('user_id', '!=', Auth::id());
+
+        if ($username) {
+            $query->where('username', 'like', '%' . $username . '%');
+        }
+
+        return $query->select([
+            'user_id',
+            'username',
+            'email',
+        ])->get();
     }
 }

--- a/app/Services/FriendService.php
+++ b/app/Services/FriendService.php
@@ -104,7 +104,7 @@ class FriendService
             ];
         }
 
-        return null; 
+        return null;
     }
 
     public function acceptFriendRequest(string $requestId): array
@@ -211,7 +211,7 @@ class FriendService
             ]
         ];
     }
-    
+
     /**
      * Cancel a friend request that the user has sent
      *
@@ -221,10 +221,10 @@ class FriendService
     public function cancelFriendRequest(string $requestId): array
     {
         $user = Auth::user();
-        
+
         try {
             $this->friendRequestRepository->cancelFriendRequest($requestId, $user->user_id);
-            
+
             return [
                 'success' => true,
                 'message' => 'Đã xóa lời mời kết bạn thành công'

--- a/app/Services/FriendService.php
+++ b/app/Services/FriendService.php
@@ -186,8 +186,6 @@ class FriendService
             ]
         ];
     }
-
-
     public function getSentFriendRequests(): array
     {
         $user = Auth::user();
@@ -212,6 +210,36 @@ class FriendService
                 'requests' => $formattedRequests
             ]
         ];
+    }
+    
+    /**
+     * Cancel a friend request that the user has sent
+     *
+     * @param string $requestId
+     * @return array
+     */
+    public function cancelFriendRequest(string $requestId): array
+    {
+        $user = Auth::user();
+        
+        try {
+            $this->friendRequestRepository->cancelFriendRequest($requestId, $user->user_id);
+            
+            return [
+                'success' => true,
+                'message' => 'Đã xóa lời mời kết bạn thành công'
+            ];
+        } catch (InvalidParamException $e) {
+            return [
+                'success' => false,
+                'message' => $e->getMessage()
+            ];
+        } catch (\Exception $e) {
+            return [
+                'success' => false,
+                'message' => 'Có lỗi xảy ra khi xóa lời mời kết bạn'
+            ];
+        }
     }
 
     public function getFriendsList(): array

--- a/app/Services/Interfaces/UserServiceInterface.php
+++ b/app/Services/Interfaces/UserServiceInterface.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Services\Interfaces;
+
+use App\DTOs\UserDTO;
+use App\DTOs\UserStatsDTO;
+use Illuminate\Http\UploadedFile;
+
+interface UserServiceInterface
+{
+    /**
+     * Get the current authenticated user
+     *
+     * @return UserDTO
+     */
+    public function getCurrentUser(): UserDTO;
+
+    /**
+     * Update user profile information
+     *
+     * @param UserDTO $userDTO
+     * @return UserDTO
+     */
+    public function updateProfile(UserDTO $userDTO): UserDTO;
+
+    /**
+     * Change user password
+     *
+     * @param string $currentPassword
+     * @param string $newPassword
+     * @return bool
+     */
+    public function changePassword(string $currentPassword, string $newPassword): bool;
+
+    /**
+     * Upload user avatar
+     *
+     * @param UploadedFile $avatar
+     * @return string
+     */
+    public function uploadAvatar(UploadedFile $avatar): string;
+
+    /**
+     * Get user statistics
+     *
+     * @return UserStatsDTO
+     */
+    public function getUserStats(): UserStatsDTO;
+
+    /**
+     * Update user streak
+     *
+     * @param int $streak
+     * @param bool $isNewRecord
+     * @return UserDTO
+     */
+    public function updateStreak(int $streak, bool $isNewRecord = false): UserDTO;
+
+    /**
+     * Get all users with optional username search
+     *
+     * @param string|null $username
+     * @return array
+     */
+    public function getAllUsers(?string $username = null): array;
+}

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -2,7 +2,8 @@
 
 namespace App\Services;
 
-use App\Repositories\UserRepository;
+use App\Repositories\Interfaces\UserRepositoryInterface;
+use App\Services\Interfaces\UserServiceInterface;
 use App\DTOs\UserDTO;
 use App\DTOs\UserStatsDTO;
 use Illuminate\Support\Facades\Hash;
@@ -13,7 +14,7 @@ class UserService implements UserServiceInterface
 {
     protected $userRepository;
 
-    public function __construct(UserRepository $userRepository)
+    public function __construct(UserRepositoryInterface $userRepository)
     {
         $this->userRepository = $userRepository;
     }
@@ -32,54 +33,75 @@ class UserService implements UserServiceInterface
     public function changePassword(string $currentPassword, string $newPassword): bool
     {
         $user = $this->userRepository->getCurrentUser();
-        
+
         if (!Hash::check($currentPassword, $user->password)) {
             return false;
         }
-        
+
         return $this->userRepository->updatePassword($user, $newPassword);
     }
 
     public function uploadAvatar(UploadedFile $avatar): string
     {
         $user = $this->userRepository->getCurrentUser();
-        
+
         if ($user->avatar !== 'default-avatar.png') {
             Storage::disk('public')->delete('avatars/' . $user->avatar);
         }
-        
+
         $filename = time() . '_' . $user->user_id . '.' . $avatar->getClientOriginalExtension();
         $path = $avatar->storeAs('avatars', $filename, 'public');
-        
+
         $this->userRepository->updateAvatar($user, $filename);
-        
+
         return $path;
     }
 
     public function getUserStats(): UserStatsDTO
     {
         $user = $this->userRepository->getCurrentUser();
-        
+
         $learningProgress = [
             'completed_lessons' => 0, // Placeholder
             'mastered_words' => 0,    // Placeholder
         ];
-        
+
         return UserStatsDTO::fromUser($user, $learningProgress);
     }
 
     public function updateStreak(int $streak, bool $isNewRecord = false): UserDTO
     {
         $user = $this->userRepository->getCurrentUser();
-        
+
         $updateData = ['current_streak' => $streak];
-        
+
         if ($isNewRecord && $streak > $user->longest_streak) {
             $updateData['longest_streak'] = $streak;
         }
-        
+
         $updatedUser = $this->userRepository->updateStats($user, $updateData);
-        
+
         return UserDTO::fromModel($updatedUser);
+    }
+
+    /**
+     * Get all users with optional username search
+     *
+     * @param string|null $username
+     * @return array
+     */
+    public function getAllUsers(?string $username = null): array
+    {
+        $users = $this->userRepository->getAllUsers($username);
+
+        return $users->map(function ($user) {
+            return [
+                'user_id' => $user->user_id,
+                'username' => $user->username,
+                'full_name' => $user->full_name ?? '',
+                'avatar' => $user->avatar,
+                'email' => $user->email
+            ];
+        })->toArray();
     }
 }

--- a/documentation/api/cancel_friend_request.md
+++ b/documentation/api/cancel_friend_request.md
@@ -1,0 +1,94 @@
+# API Endpoint: Cancel Friend Request
+
+## Overview
+API này cho phép người dùng hủy bỏ lời mời kết bạn mà họ đã gửi cho người dùng khác. Chỉ người gửi lời mời mới có quyền hủy bỏ lời mời đó.
+
+## Endpoint
+
+```
+DELETE /api/v1/friends/requests/{requestId}/cancel
+```
+
+## Authentication
+Yêu cầu token JWT trong header Authorization.
+
+```
+Authorization: Bearer {your_jwt_token}
+```
+
+## Parameters
+
+| Parameter | Type   | Required | Description                          |
+|-----------|--------|----------|--------------------------------------|
+| requestId | string | Yes      | ID của lời mời kết bạn cần hủy bỏ   |
+
+## Response
+
+### Success Response (200 OK)
+
+```json
+{
+  "success": true,
+  "message": "Đã xóa lời mời kết bạn thành công"
+}
+```
+
+### Error Response (400 Bad Request)
+
+```json
+{
+  "success": false,
+  "message": "Không tìm thấy lời mời kết bạn"
+}
+```
+
+HOẶC
+
+```json
+{
+  "success": false,
+  "message": "Bạn không có quyền xóa lời mời kết bạn này"
+}
+```
+
+HOẶC
+
+```json
+{
+  "success": false,
+  "message": "Lời mời kết bạn đã được xử lý trước đó"
+}
+```
+
+### Error Response (401 Unauthorized)
+
+```json
+{
+  "message": "Unauthenticated."
+}
+```
+
+## Example Usage
+
+### Request
+
+```
+DELETE /api/v1/friends/requests/12345/cancel
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+### Success Response
+
+```json
+{
+  "success": true,
+  "message": "Đã xóa lời mời kết bạn thành công"
+}
+```
+
+## Implementation Notes
+
+- Chỉ người dùng đã gửi lời mời kết bạn mới có thể hủy bỏ lời mời đó
+- Lời mời cần phải ở trạng thái "pending" mới có thể bị hủy bỏ
+- Sau khi hủy bỏ, lời mời sẽ bị xóa khỏi hệ thống
+- Endpoint này có thể được sử dụng từ giao diện danh sách lời mời đã gửi

--- a/routes/v1/friends.php
+++ b/routes/v1/friends.php
@@ -8,9 +8,9 @@ Route::prefix('friends')->middleware(['jwt.auth'])->group(function () {
     // Friend requests
     Route::post('/requests', [FriendController::class, 'sendFriendRequest']);
     Route::get('/requests/received', [FriendController::class, 'getPendingRequests']);
-    Route::get('/requests/sent', [FriendController::class, 'getSentRequests']);
-    Route::post('/requests/{requestId}/accept', [FriendController::class, 'acceptFriendRequest']);
+    Route::get('/requests/sent', [FriendController::class, 'getSentRequests']);    Route::post('/requests/{requestId}/accept', [FriendController::class, 'acceptFriendRequest']);
     Route::post('/requests/{requestId}/reject', [FriendController::class, 'rejectFriendRequest']);
+    Route::delete('/requests/{requestId}/cancel', [FriendController::class, 'cancelFriendRequest']);
 
     // Friends management
     Route::get('/', [FriendController::class, 'getFriendsList']);

--- a/routes/v1/friends.php
+++ b/routes/v1/friends.php
@@ -8,7 +8,8 @@ Route::prefix('friends')->middleware(['jwt.auth'])->group(function () {
     // Friend requests
     Route::post('/requests', [FriendController::class, 'sendFriendRequest']);
     Route::get('/requests/received', [FriendController::class, 'getPendingRequests']);
-    Route::get('/requests/sent', [FriendController::class, 'getSentRequests']);    Route::post('/requests/{requestId}/accept', [FriendController::class, 'acceptFriendRequest']);
+    Route::get('/requests/sent', [FriendController::class, 'getSentRequests']);
+    Route::post('/requests/{requestId}/accept', [FriendController::class, 'acceptFriendRequest']);
     Route::post('/requests/{requestId}/reject', [FriendController::class, 'rejectFriendRequest']);
     Route::delete('/requests/{requestId}/cancel', [FriendController::class, 'cancelFriendRequest']);
 

--- a/routes/v1/user.php
+++ b/routes/v1/user.php
@@ -11,5 +11,6 @@ Route::middleware(['jwt.auth'])->group(function () {
     Route::post('/user/change-password', [UserController::class, 'changePassword']);
     Route::post('/user/avatar', [UserController::class, 'uploadAvatar']);
     Route::get('/user/stats', [UserController::class, 'getStats']);
+    Route::get('/users', [UserController::class, 'getAllUsers']);
 });
 


### PR DESCRIPTION
## eheh

Pull request này thêm hai tính năng mới vào hệ thống:

1. **Hủy lời mời kết bạn đã gửi**: Cho phép người dùng hủy lời mời kết bạn mà họ đã gửi trước đó.
2. **Tìm kiếm người dùng**: Thêm API để lấy danh sách người dùng và tìm kiếm theo username để gửi lời mời kết bạn.

## Các thay đổi chính

### 1. Hủy lời mời kết bạn
- Thêm phương thức `cancelFriendRequest` vào FriendRequestRepositoryInterface
- Triển khai phương thức trong FriendRequestRepository để xóa lời mời
- Thêm logic xử lý trong FriendService
- Tạo endpoint mới trong FriendController: `DELETE /api/v1/friends/requests/{requestId}/cancel`
- Cập nhật routes để hỗ trợ tính năng mới

### 2. Tìm kiếm người dùng
- Cập nhật UserRepositoryInterface và UserRepository với phương thức `getAllUsers`
- Thêm tính năng tìm kiếm theo username thông qua query parameter
- Tạo endpoint mới: `GET /api/v1/users`
- Xử lý trả về thông tin người dùng phù hợp với yêu cầu kết bạn

## Kiểm thử
- Đã kiểm thử thủ công tất cả các API:
  - Tạo lời mời kết bạn và hủy thành công
  - Tìm kiếm người dùng với và không có username
  - Xác minh các trường hợp lỗi được xử lý đúng cách

## Documentation
- Đã thêm tài liệu mới: `documentation/api/cancel_friend_request.md`
- Cập nhật tài liệu API cho tính năng tìm kiếm người dùng
