### PR TITLE
feat: complete leaderboard functionality and fix date comparison in daily mission reward

### DIFF
--- a/app/DTOs/LeaderboardDTO.php
+++ b/app/DTOs/LeaderboardDTO.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\DTOs;
+
+class LeaderboardDTO
+{
+    public function __construct(
+        public readonly int $position,
+        public readonly string $userId,
+        public readonly string $username,
+        public readonly string $fullName,
+        public readonly string $avatar,
+        public readonly string $rank,
+        public readonly float $totalScore,
+        public readonly bool $isCurrentUser
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            position: $data['position'],
+            userId: $data['user_id'],
+            username: $data['username'],
+            fullName: $data['full_name'] ?? '',
+            avatar: $data['avatar'],
+            rank: $data['rank'],
+            totalScore: $data['total_score'],
+            isCurrentUser: $data['is_current_user'] ?? false
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'position' => $this->position,
+            'user_id' => $this->userId,
+            'username' => $this->username,
+            'full_name' => $this->fullName,
+            'avatar' => $this->avatar,
+            'rank' => $this->rank,
+            'total_score' => $this->totalScore,
+            'is_current_user' => $this->isCurrentUser
+        ];
+    }
+}

--- a/app/DTOs/LeaderboardResponseDTO.php
+++ b/app/DTOs/LeaderboardResponseDTO.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\DTOs;
+
+class LeaderboardResponseDTO
+{
+    public function __construct(
+        public readonly array $leaderboard,
+        public readonly ?LeaderboardDTO $currentUserRank,
+        public readonly int $totalUsers
+    ) {}
+
+    public function toArray(): array
+    {
+        return [
+            'leaderboard' => array_map(fn($item) => $item->toArray(), $this->leaderboard),
+            'current_user' => $this->currentUserRank?->toArray(),
+            'total_users' => $this->totalUsers
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/V1/LeaderboardController.php
+++ b/app/Http/Controllers/Api/V1/LeaderboardController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Services\Interfaces\LeaderboardServiceInterface;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+class LeaderboardController extends Controller
+{
+    public function __construct(
+        private LeaderboardServiceInterface $leaderboardService
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $limit = $request->input('limit', 10);
+        $page = $request->input('page', 1);
+        
+        $leaderboardResponse = $this->leaderboardService->getLeaderboard($limit, $page);
+        
+        return response()->json([
+            'status' => 'success',
+            'data' => $leaderboardResponse->toArray(),
+            'meta' => [
+                'page' => (int)$page,
+                'limit' => (int)$limit,
+                'total' => $leaderboardResponse->totalUsers
+            ]
+        ]);
+    }
+
+    public function getCurrentUserRank(): JsonResponse
+    {
+        if (!auth()->check()) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Người dùng chưa đăng nhập'
+            ], 401);
+        }
+        
+        $userId = auth()->id();
+        $position = $this->leaderboardService->getUserLeaderboardPosition($userId);
+        
+        if ($position === null) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Không tìm thấy thứ hạng của người dùng'
+            ], 404);
+        }
+        
+        return response()->json([
+            'status' => 'success',
+            'data' => [
+                'position' => $position
+            ]
+        ]);
+    }
+}

--- a/app/Models/Leaderboard.php
+++ b/app/Models/Leaderboard.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Leaderboard extends Model
+{
+    use HasFactory;
+
+    protected $table = 'leaderboard';
+    protected $primaryKey = 'leaderboard_id';
+    public $timestamps = true;
+
+    protected $fillable = [
+        'user_id',
+        'rank',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id', 'user_id');
+    }
+}

--- a/app/Providers/RepositoryServiceProvider.php
+++ b/app/Providers/RepositoryServiceProvider.php
@@ -38,6 +38,10 @@ use App\Repositories\Interfaces\UserDailyMissionRepositoryInterface;
 use App\Repositories\UserDailyMissionRepository;
 use App\Services\Interfaces\UserDailyMissionServiceInterface;
 use App\Services\UserDailyMissionService;
+use App\Repositories\Interfaces\LeaderboardRepositoryInterface;
+use App\Repositories\LeaderboardRepository;
+use App\Services\Interfaces\LeaderboardServiceInterface;
+use App\Services\LeaderboardService;
 
 
 class RepositoryServiceProvider extends ServiceProvider
@@ -92,6 +96,11 @@ class RepositoryServiceProvider extends ServiceProvider
             \App\Repositories\UserRepository::class
         );
 
+        $this->app->bind(
+            \App\Repositories\Interfaces\LeaderboardRepositoryInterface::class,
+            \App\Repositories\LeaderboardRepository::class
+        );
+
         // Đăng ký service bindings
         $this->app->bind(
             \App\Services\AuthServiceInterface::class,
@@ -121,6 +130,11 @@ class RepositoryServiceProvider extends ServiceProvider
         $this->app->bind(
             \App\Services\Interfaces\MissionServiceInterface::class,
             \App\Services\MissionService::class
+        );
+
+        $this->app->bind(
+            \App\Services\Interfaces\LeaderboardServiceInterface::class,
+            \App\Services\LeaderboardService::class
         );
 
         $this->app->bind(MissionRepositoryInterface::class, MissionRepository::class);

--- a/app/Repositories/Interfaces/LeaderboardRepositoryInterface.php
+++ b/app/Repositories/Interfaces/LeaderboardRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace App\Repositories\Interfaces;
+
+interface LeaderboardRepositoryInterface
+{
+    public function getLeaderboard(int $limit = 10, int $page = 1);
+    public function getUserRank(string $userId);
+    public function getTotalUsers();
+}

--- a/app/Repositories/LeaderboardRepository.php
+++ b/app/Repositories/LeaderboardRepository.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\User;
+use App\Models\Leaderboard;
+use App\Models\UserProgress;
+use App\Repositories\Interfaces\LeaderboardRepositoryInterface;
+use Illuminate\Support\Facades\DB;
+
+class LeaderboardRepository implements LeaderboardRepositoryInterface
+{
+    public function getLeaderboard(int $limit = 10, int $page = 1)
+    {
+        $offset = ($page - 1) * $limit;
+
+        return DB::table('users')
+            ->select(
+                'users.user_id',
+                'users.username',
+                'users.full_name',
+                'users.avatar',
+                'leaderboard.rank',
+                DB::raw('SUM(user_progress.score) as total_score')
+            )
+            ->leftJoin('leaderboard', 'users.user_id', '=', 'leaderboard.user_id')
+            ->leftJoin('user_progress', 'users.user_id', '=', 'user_progress.user_id')
+            ->where('users.is_active', true)
+            ->groupBy('users.user_id', 'users.username', 'users.full_name', 'users.avatar', 'leaderboard.rank')
+            ->orderBy('total_score', 'desc')
+            ->limit($limit)
+            ->offset($offset)
+            ->get();
+    }
+
+    public function getUserRank(string $userId)
+    {
+        $userRankSubquery = DB::table('users')
+            ->select(
+                'users.user_id',
+                'users.username',
+                'users.full_name',
+                'users.avatar',
+                'leaderboard.rank',
+                DB::raw('SUM(user_progress.score) as total_score'),
+                DB::raw('RANK() OVER (ORDER BY SUM(user_progress.score) DESC) as position')
+            )
+            ->leftJoin('leaderboard', 'users.user_id', '=', 'leaderboard.user_id')
+            ->leftJoin('user_progress', 'users.user_id', '=', 'user_progress.user_id')
+            ->where('users.is_active', true)
+            ->groupBy('users.user_id', 'users.username', 'users.full_name', 'users.avatar', 'leaderboard.rank');
+            
+        return DB::table(DB::raw("({$userRankSubquery->toSql()}) as ranked_users"))
+            ->mergeBindings($userRankSubquery)
+            ->where('user_id', $userId)
+            ->first();
+    }
+
+    public function getTotalUsers()
+    {
+        return User::where('is_active', true)->count();
+    }
+}

--- a/app/Services/Interfaces/LeaderboardServiceInterface.php
+++ b/app/Services/Interfaces/LeaderboardServiceInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Services\Interfaces;
+
+use App\DTOs\LeaderboardResponseDTO;
+
+interface LeaderboardServiceInterface
+{
+    public function getLeaderboard(int $limit = 10, int $page = 1): LeaderboardResponseDTO;
+    public function getUserLeaderboardPosition(string $userId): ?int;
+}

--- a/app/Services/LeaderboardService.php
+++ b/app/Services/LeaderboardService.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Services;
+
+use App\DTOs\LeaderboardDTO;
+use App\DTOs\LeaderboardResponseDTO;
+use App\Repositories\Interfaces\LeaderboardRepositoryInterface;
+use App\Services\Interfaces\LeaderboardServiceInterface;
+use Illuminate\Support\Facades\Auth;
+
+class LeaderboardService implements LeaderboardServiceInterface
+{
+    public function __construct(
+        private LeaderboardRepositoryInterface $leaderboardRepository
+    ) {}
+
+    public function getLeaderboard(int $limit = 10, int $page = 1): LeaderboardResponseDTO
+    {
+        $leaderboardData = $this->leaderboardRepository->getLeaderboard($limit, $page);
+        $totalUsers = $this->leaderboardRepository->getTotalUsers();
+        
+        $currentUserId = Auth::id();
+        $currentUserRank = null;
+        
+        $leaderboardDTOs = [];
+        $position = ($page - 1) * $limit + 1;
+        
+        foreach ($leaderboardData as $index => $userData) {
+            $isCurrentUser = $currentUserId && $userData->user_id === $currentUserId;
+            
+            $leaderboardDTO = LeaderboardDTO::fromArray([
+                'position' => $position + $index,
+                'user_id' => $userData->user_id,
+                'username' => $userData->username,
+                'full_name' => $userData->full_name,
+                'avatar' => $userData->avatar,
+                'rank' => $userData->rank ?? 'Bronze',
+                'total_score' => $userData->total_score ?? 0,
+                'is_current_user' => $isCurrentUser
+            ]);
+            
+            $leaderboardDTOs[] = $leaderboardDTO;
+            
+            if ($isCurrentUser) {
+                $currentUserRank = $leaderboardDTO;
+            }
+        }
+        
+        if ($currentUserId && !$currentUserRank) {
+            $currentUserData = $this->leaderboardRepository->getUserRank($currentUserId);
+            if ($currentUserData) {
+                $currentUserRank = LeaderboardDTO::fromArray([
+                    'position' => $currentUserData->position,
+                    'user_id' => $currentUserData->user_id,
+                    'username' => $currentUserData->username,
+                    'full_name' => $currentUserData->full_name,
+                    'avatar' => $currentUserData->avatar,
+                    'rank' => $currentUserData->rank ?? 'Bronze',
+                    'total_score' => $currentUserData->total_score ?? 0,
+                    'is_current_user' => true
+                ]);
+            }
+        }
+        
+        return new LeaderboardResponseDTO(
+            leaderboard: $leaderboardDTOs,
+            currentUserRank: $currentUserRank,
+            totalUsers: $totalUsers
+        );
+    }
+
+    public function getUserLeaderboardPosition(string $userId): ?int
+    {
+        $userData = $this->leaderboardRepository->getUserRank($userId);
+        return $userData ? $userData->position : null;
+    }
+}

--- a/app/Services/UserDailyMissionService.php
+++ b/app/Services/UserDailyMissionService.php
@@ -145,7 +145,10 @@ class UserDailyMissionService implements UserDailyMissionServiceInterface
                 throw new \Exception('Không tìm thấy nhiệm vụ.');
             }
 
-            if ($userMission->user_id !== $userId || Carbon::parse($userMission->date)->toDateString() !== Carbon::today()->toDateString()) {
+            if (
+                $userMission->user_id !== $userId ||
+                Carbon::parse($userMission->date)->isSameDay(Carbon::today()) === false
+            ) {
                 DB::rollback();
                 throw new \Exception('Không thể nhận phần thưởng cho nhiệm vụ không thuộc về bạn hoặc không phải hôm nay.');
             }

--- a/database/migrations/2025_04_04_194544_create_users_table.php
+++ b/database/migrations/2025_04_04_194544_create_users_table.php
@@ -18,7 +18,7 @@ return new class extends Migration
             $table->string('password', 255)->notNullable();
             $table->string('full_name', 50)->nullable();
             $table->enum('gender', ['male', 'female', 'other']);
-            $table->string('avatar')->default('default-avatar.png')->change();
+            $table->string('avatar')->default('default-avatar.png');
             $table->unsignedBigInteger('role_id')->default(2); // Can sua lai trong database 
             $table->integer('coins')->default(0);
             $table->integer('lives')->default(5);

--- a/routes/v1/leaderboard.php
+++ b/routes/v1/leaderboard.php
@@ -1,0 +1,11 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\V1\LeaderboardController;
+
+Route::middleware(['jwt.auth'])->group(function () {
+    Route::prefix('leaderboard')->group(function () {
+        Route::get('/', [LeaderboardController::class, 'index']);
+        Route::get('/my-rank', [LeaderboardController::class, 'getCurrentUserRank']);
+    });
+});


### PR DESCRIPTION
feat: complete leaderboard functionality and fix date comparison in daily mission reward

- Implemented full leaderboard feature including controller, service, and DTO.
- Supports pagination and retrieving the current user's rank.
- Uses auth()->id() to identify the authenticated user.
- Fixed date comparison issue in daily mission reward logic:
  + Replaced toDateString() comparison with Carbon::parse()->isSameDay() to ensure correct behavior when comparing date vs datetime.
